### PR TITLE
Replace shell process by Solr process

### DIFF
--- a/HISTORY.txt
+++ b/HISTORY.txt
@@ -8,6 +8,9 @@ Changelog
   This fixes handling of decomposed unicode (aka NFD, NFKD).
   [buchi]
 
+- Replace shell process by Solr process when starting in foreground.
+  [buchi]
+
 
 1.2.0 (2018-05-25)
 ------------------

--- a/ftw/recipe/solr/README.txt
+++ b/ftw/recipe/solr/README.txt
@@ -137,12 +137,12 @@ We should also have a startup script::
     <BLANKLINE>
     start_fg() {
         cd "$SOLR_SERVER_DIR"
-        "$JAVACMD" "${SOLR_START_OPT[@]}" -jar start.jar --module=http
+        exec "$JAVACMD" "${SOLR_START_OPT[@]}" -jar start.jar --module=http
     }
     <BLANKLINE>
     start_console() {
         cd "$SOLR_SERVER_DIR"
-        "$JAVACMD" "${SOLR_START_OPT[@]}" -Dsolr.log.muteconsole -jar start.jar --module=http
+        exec "$JAVACMD" "${SOLR_START_OPT[@]}" -Dsolr.log.muteconsole -jar start.jar --module=http
     }
     <BLANKLINE>
     stop() {

--- a/ftw/recipe/solr/templates/startup.tmpl
+++ b/ftw/recipe/solr/templates/startup.tmpl
@@ -31,12 +31,12 @@ start() {
 
 start_fg() {
     cd "$SOLR_SERVER_DIR"
-    "$JAVACMD" "${SOLR_START_OPT[@]}" -jar start.jar --module=http
+    exec "$JAVACMD" "${SOLR_START_OPT[@]}" -jar start.jar --module=http
 }
 
 start_console() {
     cd "$SOLR_SERVER_DIR"
-    "$JAVACMD" "${SOLR_START_OPT[@]}" -Dsolr.log.muteconsole -jar start.jar --module=http
+    exec "$JAVACMD" "${SOLR_START_OPT[@]}" -Dsolr.log.muteconsole -jar start.jar --module=http
 }
 
 stop() {


### PR DESCRIPTION
Fixes #1

Before this fix the Solr process was spawned as a child process of a shell
process. When run with supervisord it was necessary to stop Solr as group (kill
the Solr and the shell process). However this can lead to problems when
restarting Solr because the Solr process may need more time to stop than the
shell process but supervisord is only checking the exit status of the parent
process when stopping a process group. This can lead to the situation that the
new Solr process is started while the old one is still running.

To avoid this issue, we simply replace the shell process by the Solr process.