### PR TITLE
Backport: Respect SOLR environment variables.

### DIFF
--- a/HISTORY.txt
+++ b/HISTORY.txt
@@ -4,7 +4,7 @@ Changelog
 1.2.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Backport: Respect SOLR environment variables set outside of the startup script [jone].
 
 
 1.2.1 (2018-09-20)

--- a/ftw/recipe/solr/README.txt
+++ b/ftw/recipe/solr/README.txt
@@ -110,12 +110,12 @@ We should also have a startup script::
     JVM_OPTS=(${DEFAULT_JVM_OPTS[@]} -Xms512m -Xmx512m -Xss256k)
     <BLANKLINE>
     JAVACMD="java"
-    PID_FILE="/sample-buildout/var/solr/solr.pid"
+    PID_FILE=${PID_FILE:="/sample-buildout/var/solr/solr.pid"}
     <BLANKLINE>
-    SOLR_PORT="8983"
-    SOLR_HOME="/sample-buildout/var/solr"
-    SOLR_INSTALL_DIR="/sample-buildout/parts/solr"
-    SOLR_SERVER_DIR="/sample-buildout/parts/solr/server"
+    SOLR_PORT=${SOLR_PORT:="8983"}
+    SOLR_HOME=${SOLR_HOME:="/sample-buildout/var/solr"}
+    SOLR_INSTALL_DIR=${SOLR_INSTALL_DIR:="/sample-buildout/parts/solr"}
+    SOLR_SERVER_DIR=${SOLR_SERVER_DIR:="/sample-buildout/parts/solr/server"}
     <BLANKLINE>
     SOLR_START_OPT=('-server' \
     "${JVM_OPTS[@]}" \

--- a/ftw/recipe/solr/templates/startup.tmpl
+++ b/ftw/recipe/solr/templates/startup.tmpl
@@ -4,12 +4,12 @@ DEFAULT_JVM_OPTS="-Dfile.encoding=UTF-8"
 JVM_OPTS=(${DEFAULT_JVM_OPTS[@]} {{ jvm_opts }})
 
 JAVACMD="java"
-PID_FILE="{{ pid_file }}"
+PID_FILE=${PID_FILE:="{{ pid_file }}"}
 
-SOLR_PORT="{{ solr_port }}"
-SOLR_HOME="{{ solr_home }}"
-SOLR_INSTALL_DIR="{{ solr_install_dir }}"
-SOLR_SERVER_DIR="{{ solr_install_dir }}/server"
+SOLR_PORT=${SOLR_PORT:="{{ solr_port }}"}
+SOLR_HOME=${SOLR_HOME:="{{ solr_home }}"}
+SOLR_INSTALL_DIR=${SOLR_INSTALL_DIR:="{{ solr_install_dir }}"}
+SOLR_SERVER_DIR=${SOLR_SERVER_DIR:="{{ solr_install_dir }}/server"}
 
 SOLR_START_OPT=('-server' \
 "${JVM_OPTS[@]}" \


### PR DESCRIPTION
When a SOLR-env variable is set outside of the startup script, it should be respected. The values generated in the script are now used as default. This makes it possible to change the configuration from outside, for example in tests.

See #7 