### PR TITLE
Add -f flag to ps command in bin/solr script

### DIFF
--- a/ftw/recipe/solr/README.txt
+++ b/ftw/recipe/solr/README.txt
@@ -202,7 +202,7 @@ We should also have a startup script::
     stop() {
         if [ -e $PID_FILE ]; then
             pid=`cat "$PID_FILE"`
-            ps -p $pid | grep start.jar > /dev/null 2>&1
+            ps -p $pid -f | grep start.jar > /dev/null 2>&1
             if [ $? -eq 0 ]
             then
                 kill -TERM $pid
@@ -219,7 +219,7 @@ We should also have a startup script::
     status() {
         if [ -e $PID_FILE ]; then
             pid=`cat "$PID_FILE"`
-            ps -p $pid | grep start.jar > /dev/null 2>&1
+            ps -p $pid -f | grep start.jar > /dev/null 2>&1
             if [ $? -eq 0 ]
             then
                 echo "Solr running with pid $pid."

--- a/ftw/recipe/solr/README.txt
+++ b/ftw/recipe/solr/README.txt
@@ -19,17 +19,21 @@ We'll start by creating a simple buildout that uses our recipe::
     ... md5sum = 95e828f50d34c1b40e3afa8630138664
     ...
     ... cores = core1
+    ...
+    ... [versions]
+    ... setuptools = <45.0
     ... """.format(server_url=server_url))
 
 Running the buildout gives us::
 
     >>> print system(buildout)
     Getting distribution for 'jinja2'.
-    Got Jinja2 2.10.1.
+    Got Jinja2 2.10.3.
     Getting distribution for 'zc.recipe.egg>=2.0.6'.
     Got zc.recipe.egg 2.0.7.
     Installing solr.
     Downloading http://test.server/solr-7.2.1.tgz
+    WARNING: The easy_install command is deprecated and will be removed in a future version.
     <BLANKLINE>
 
 We should have a Solr distribution in the parts directory::
@@ -279,6 +283,9 @@ We can provide the Solr configuration from an egg::
     ... conf = /ftw/recipe/solr/conf
     ...
     ... cores = core1
+    ...
+    ... [versions]
+    ... setuptools = <45.0
     ... """.format(server_url=server_url))
 
 Running the buildout gives us::

--- a/ftw/recipe/solr/templates/startup.tmpl
+++ b/ftw/recipe/solr/templates/startup.tmpl
@@ -42,7 +42,7 @@ start_console() {
 stop() {
     if [ -e $PID_FILE ]; then
         pid=`cat "$PID_FILE"`
-        ps -p $pid | grep start.jar > /dev/null 2>&1
+        ps -p $pid -f | grep start.jar > /dev/null 2>&1
         if [ $? -eq 0 ]
         then
             kill -TERM $pid
@@ -59,7 +59,7 @@ stop() {
 status() {
     if [ -e $PID_FILE ]; then
         pid=`cat "$PID_FILE"`
-        ps -p $pid | grep start.jar > /dev/null 2>&1
+        ps -p $pid -f | grep start.jar > /dev/null 2>&1
         if [ $? -eq 0 ]
         then
             echo "Solr running with pid $pid."


### PR DESCRIPTION
The bin/solr script doesn't work on our servers correctly, because the default
`ps -p <pid>` doesn't output the whole command, so the script can't find the
running solr instance. The script looks for a process with the given pid stored
in the pid file and checks if the output contains "start.jar", which is not the
case on our servers:

```
[ysi@kek 25-ris-solr-web]$ ps -p 31337
  PID TTY          TIME CMD
31337 ?        00:00:20 java
```

To address this issue, use the `-f` (full format) command to print the whole command:

```
[ysi@kek 25-ris-solr-web]$ ps -p 31337 -f | cat
UID        PID  PPID  C STIME TTY          TIME CMD
zope     31337     1  2 11:16 ?        00:00:21 java -server
-Dfile.encoding=UTF-8 -Xms512m -Xmx512m -Xss256k -Djetty.host=localhost
-Djetty.port=12501 -Djetty.home=/apps/25-ris-solr-web/parts/solr/server
-Dsolr.solr.home=/apps/25-ris-solr-web/var/solr
-Dsolr.install.dir=/apps/25-ris-solr-web/parts/solr
-Dsolr.log.dir=/apps/25-ris-solr-web/var/log
-Dlog4j.configuration=file:/apps/25-ris-solr-web/parts/solr/log4j2.xml
-Dsolr.log.muteconsole -jar start.jar --module=http
```