### PR TITLE
Fix tests by replacing hardcoded version numbers with ellipsis in doctests.

### DIFF
--- a/ftw/recipe/solr/README.txt
+++ b/ftw/recipe/solr/README.txt
@@ -28,9 +28,9 @@ Running the buildout gives us::
 
     >>> print system(buildout)
     Getting distribution for 'jinja2'.
-    Got Jinja2 2.10.3.
+    Got Jinja2 ...
     Getting distribution for 'zc.recipe.egg>=2.0.6'.
-    Got zc.recipe.egg 2.0.7.
+    Got zc.recipe.egg ...
     Installing solr.
     Downloading http://test.server/solr-7.2.1.tgz
     WARNING: The easy_install command is deprecated and will be removed in a future version.


### PR DESCRIPTION
Fix tests by replacing hardcoded version numbers with ellipsis in doctests.

Fixes https://ci.4teamwork.ch/builds/312035/tasks/515805