### PR TITLE
Add shardsWhitelist to template.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 Introduction
 ============
 
-This recipe installs a `Solr <http://lucene.apache.org/solr/>`_ 
+This recipe installs a `Solr <http://lucene.apache.org/solr/>`_
 server with buildout.
 
 It's kept as simple as possible and contrary to `collective.recipe.solrinstance`
@@ -41,7 +41,7 @@ md5sum
     MD5 checksum of Solr distribution.
 
 jvm-opts
-    Can be used to configure JVM options. Defaults to 
+    Can be used to configure JVM options. Defaults to
     ``-Xms512m -Xmx512m -Xss256k``
 
 conf
@@ -50,6 +50,11 @@ conf
 conf-egg
     If provided, the path given in `conf` is prepended with the path of the
     given egg.
+
+shards-whitelist
+    If specified, this list limits what nodes can be requested in the shards
+    request parameter. See `Configuring the ShardHandlerFactory
+    <https://lucene.apache.org/solr/guide/8_1/distributed-requests.html#configuring-the-shardhandlerfactory>`_
 
 
 Links

--- a/ftw/recipe/solr/__init__.py
+++ b/ftw/recipe/solr/__init__.py
@@ -79,6 +79,7 @@ class Recipe(object):
         parts.append(self._create_from_template(
             'solr.xml.tmpl',
             os.path.join(home_dir, 'solr.xml'),
+            shardsWhitelist=self.options.get('shards-whitelist')
         ))
 
         # Create zoo.cfg

--- a/ftw/recipe/solr/templates/solr.xml.tmpl
+++ b/ftw/recipe/solr/templates/solr.xml.tmpl
@@ -20,6 +20,8 @@
     class="HttpShardHandlerFactory">
     <int name="socketTimeout">${socketTimeout:600000}</int>
     <int name="connTimeout">${connTimeout:60000}</int>
+    {% if shardsWhitelist %}<str name="shardsWhitelist">{{ shardsWhitelist }}</str>{% endif %}
+
   </shardHandlerFactory>
 
 </solr>


### PR DESCRIPTION
Allow providing a `shardsWhitelist` option being passed to the `ShardHandlerFactory`. This allows to limits what nodes can be requested in the shards request parameter (see https://lucene.apache.org/solr/guide/8_1/distributed-requests.html#configuring-the-shardhandlerfactory)

Example `buildout.cfg` (e.g. in https://github.com/4teamwork/ris-solr/):

```
[buildout]
extends = base.cfg

[solr]
port = 12830
shards-whitelist = localhost:12830/solr/ris,localhost:10630/solr/kr
```