### PR TITLE
Add support for configoverlay

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -56,6 +56,10 @@ shards-whitelist
     request parameter. See `Configuring the ShardHandlerFactory
     <https://lucene.apache.org/solr/guide/8_1/distributed-requests.html#configuring-the-shardhandlerfactory>`_
 
+configoverlay
+    Provide a configoverlay as documented in https://lucene.apache.org/solr/guide/8_4/config-api.html.
+    This will override the default config in ``solrconfig.xml``
+
 
 Links
 =====

--- a/ftw/recipe/solr/README.txt
+++ b/ftw/recipe/solr/README.txt
@@ -363,3 +363,60 @@ The solr.xml file contains our whitelisted shards::
       </shardHandlerFactory>
     <BLANKLINE>
     </solr>
+
+
+We can override the solr settings with a configoverlay:
+
+    >>> write(sample_buildout, 'buildout.cfg',
+    ... """
+    ... [buildout]
+    ... parts = solr
+    ... index=https://pypi.python.org/simple/
+    ...
+    ... [solr]
+    ... recipe = ftw.recipe.solr
+    ... url = {server_url}solr-7.2.1.tgz
+    ... md5sum = 95e828f50d34c1b40e3afa8630138664
+    ... configoverlay =
+    ...     {{
+    ...         "initParams": {{
+    ...             "/update/**,/query,/select,/spell": {{
+    ...                 "name":"/update/**,/query,/select,/spell",
+    ...                 "path":"/update/**,/query,/select,/spell",
+    ...                 "defaults": {{
+    ...                     "update.chain":"sync.chain",
+    ...                     "df":"SearchableText"
+    ...                 }}
+    ...             }}
+    ...         }}
+    ...     }}
+    ...
+    ... cores = core1
+    ...
+    ... [versions]
+    ... setuptools = <45.0
+    ... """.format(server_url=server_url))
+
+Running the buildout gives us::
+
+    >>> print system(buildout)
+    Uninstalling solr.
+    Installing solr.
+    Downloading http://test.server/solr-7.2.1.tgz
+    <BLANKLINE>
+
+The configoverlay.json file contains our configuration::
+
+    >>> cat(sample_buildout, 'var', 'solr', 'core1', 'conf', 'configoverlay.json')
+    {
+        "initParams": {
+            "/update/**,/query,/select,/spell": {
+                "name":"/update/**,/query,/select,/spell",
+                "path":"/update/**,/query,/select,/spell",
+                "defaults": {
+                    "update.chain":"sync.chain",
+                    "df":"SearchableText"
+                }
+            }
+        }
+    }

--- a/ftw/recipe/solr/__init__.py
+++ b/ftw/recipe/solr/__init__.py
@@ -150,6 +150,18 @@ class Recipe(object):
             log_dir=log_dir,
             log4j2_xml=log4j2_xml,
         ))
+
+        # Create configoverlay.json
+        configoverlay = self.options.get('configoverlay')
+        if configoverlay:
+            for core in self.cores:
+                core_dir = os.path.join(home_dir, core)
+                core_conf_dir = os.path.join(core_dir, 'conf')
+                configoverlay_filename = os.path.join(core_conf_dir, "configoverlay.json")
+                with open(configoverlay_filename, 'wb') as f:
+                    f.write(configoverlay.encode('utf8'))
+                parts.append(configoverlay_filename)
+
         chmod_executable(startup_script)
 
         return parts


### PR DESCRIPTION
The configoverlay option allows to override the solrconfig.xml as documented in https://lucene.apache.org/solr/guide/8_4/config-api.html