### PR TITLE
Disable message lookups in log4j

### DIFF
--- a/HISTORY.txt
+++ b/HISTORY.txt
@@ -4,7 +4,8 @@ Changelog
 1.3.5 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Disable message lookups in log4j. Mitigation for CVE-2021-44228.
+  [buchi]
 
 
 1.3.4 (2020-07-31)

--- a/ftw/recipe/solr/README.txt
+++ b/ftw/recipe/solr/README.txt
@@ -183,6 +183,7 @@ We should also have a startup script::
     -Dsolr.solr.home=$SOLR_HOME \
     -Dsolr.install.dir=$SOLR_INSTALL_DIR \
     -Dsolr.log.dir=/sample-buildout/var/log \
+    -Dlog4j2.formatMsgNoLookups=true \
     -Dlog4j.configuration=/sample-buildout/parts/solr/log4j2.xml)
     <BLANKLINE>
     start() {

--- a/ftw/recipe/solr/templates/startup.tmpl
+++ b/ftw/recipe/solr/templates/startup.tmpl
@@ -19,6 +19,7 @@ SOLR_START_OPT=('-server' \
 -Dsolr.solr.home=$SOLR_HOME \
 -Dsolr.install.dir=$SOLR_INSTALL_DIR \
 -Dsolr.log.dir={{ log_dir }} \
+-Dlog4j2.formatMsgNoLookups=true \
 -Dlog4j.configuration=file:{{ log4j2_xml }})
 
 start() {


### PR DESCRIPTION
Mitigation for CVE-2021-44228
https://solr.apache.org/security.html#apache-solr-affected-by-apache-log4j-cve-2021-44228