### PR TITLE
Fix system property for Log4j configuration file

### DIFF
--- a/HISTORY.txt
+++ b/HISTORY.txt
@@ -4,7 +4,7 @@ Changelog
 1.3.6 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix system property for Log4j configuration file.
 
 
 1.3.5 (2021-12-13)

--- a/ftw/recipe/solr/README.txt
+++ b/ftw/recipe/solr/README.txt
@@ -184,7 +184,7 @@ We should also have a startup script::
     -Dsolr.install.dir=$SOLR_INSTALL_DIR \
     -Dsolr.log.dir=/sample-buildout/var/log \
     -Dlog4j2.formatMsgNoLookups=true \
-    -Dlog4j.configuration=/sample-buildout/parts/solr/log4j2.xml)
+    -Dlog4j2.configurationFile=/sample-buildout/parts/solr/log4j2.xml)
     <BLANKLINE>
     start() {
         cd "$SOLR_SERVER_DIR"

--- a/ftw/recipe/solr/templates/startup.tmpl
+++ b/ftw/recipe/solr/templates/startup.tmpl
@@ -20,7 +20,7 @@ SOLR_START_OPT=('-server' \
 -Dsolr.install.dir=$SOLR_INSTALL_DIR \
 -Dsolr.log.dir={{ log_dir }} \
 -Dlog4j2.formatMsgNoLookups=true \
--Dlog4j.configuration=file:{{ log4j2_xml }})
+-Dlog4j2.configurationFile=file:{{ log4j2_xml }})
 
 start() {
     cd "$SOLR_SERVER_DIR"


### PR DESCRIPTION
We were using a legacy property which no longer works with the newest Log4j version 2.17.0.