### PR TITLE
Add support for subdirectories in the configuration directory

### DIFF
--- a/HISTORY.txt
+++ b/HISTORY.txt
@@ -4,7 +4,8 @@ Changelog
 1.3.6 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Add support for subdirectories in the configuration directory.
+  [buchi]
 
 
 1.3.5 (2021-12-13)

--- a/ftw/recipe/solr/README.txt
+++ b/ftw/recipe/solr/README.txt
@@ -64,9 +64,10 @@ The core directory should contain a conf directory and core.properties file::
     d conf
     - core.properties
 
-The conf direcotry should contain a basic set of Solr configuration files::
+The conf directory should contain a basic set of Solr configuration files::
 
     >>> ls(sample_buildout, 'var', 'solr', 'core1', 'conf')
+    d lang
     - managed-schema
     - mapping-FoldToASCII.txt
     - solrconfig.xml
@@ -302,6 +303,7 @@ Running the buildout gives us::
 The conf directory should contain our Solr configuration files::
 
     >>> ls(sample_buildout, 'var', 'solr', 'core1', 'conf')
+    d lang
     - managed-schema
     - mapping-FoldToASCII.txt
     - solrconfig.xml

--- a/ftw/recipe/solr/__init__.py
+++ b/ftw/recipe/solr/__init__.py
@@ -193,8 +193,16 @@ class Recipe(object):
 
     def _copy_from_dir(self, src, dst):
         paths = []
-        for name in os.listdir(src):
-            dst_path = os.path.join(dst, name)
-            copyfile(os.path.join(src, name),  dst_path)
-            paths.append(dst_path)
+        for dirpath, dirnames, filenames in os.walk(src):
+            rel_path = os.path.relpath(dirpath, src)
+            for dirname in dirnames:
+                dst_path = os.path.normpath(os.path.join(dst, rel_path, dirname))
+                if not os.path.exists(dst_path):
+                    os.mkdir(dst_path)
+                paths.append(dst_path)
+            for filename in filenames:
+                dst_path = os.path.normpath(os.path.join(dst, rel_path, filename))
+                src_path = os.path.join(dirpath, filename)
+                copyfile(src_path,  dst_path)
+                paths.append(dst_path)
         return paths


### PR DESCRIPTION
The Solr `conf` directory may contain subdirectories. Until now we didn't support this.