### PR TITLE
Add support for `extra-opts` (additional options for Solr cmdline).

### DIFF
--- a/HISTORY.txt
+++ b/HISTORY.txt
@@ -4,7 +4,8 @@ Changelog
 1.3.8 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Add support for `extra-opts` (additional options for Solr cmdline).
+  [lgraf]
 
 
 1.3.7 (2022-07-05)

--- a/README.rst
+++ b/README.rst
@@ -44,6 +44,9 @@ jvm-opts
     Can be used to configure JVM options. Defaults to
     ``-Xms512m -Xmx512m -Xss256k``
 
+extra-opts
+    Extra options to pass to the Solr command line (separated by space). Empty by default.
+
 conf
     Path to a directory containing Solr configuration files.
 

--- a/ftw/recipe/solr/README.txt
+++ b/ftw/recipe/solr/README.txt
@@ -22,6 +22,7 @@ We'll start by creating a simple buildout that uses our recipe::
     ...
     ... [versions]
     ... setuptools = <45.0
+    ... zc.buildout = 2.13.8
     ... Jinja2 = <3.0.0
     ... MarkupSafe = <2.0.0
     ... """.format(server_url=server_url))
@@ -30,7 +31,7 @@ Running the buildout gives us::
 
     >>> print system(buildout)
     Getting distribution for 'zc.recipe.egg>=2.0.6'.
-    Got zc.recipe.egg ...
+    Got zc.recipe.egg 2.0.7.
     Installing solr.
     Downloading http://test.server/solr-7.2.1.tgz
     WARNING: The easy_install command is deprecated and will be removed in a future version.
@@ -288,6 +289,7 @@ We can provide the Solr configuration from an egg::
     ...
     ... [versions]
     ... setuptools = <45.0
+    ... zc.buildout = 2.13.8
     ... Jinja2 = <3.0.0
     ... MarkupSafe = <2.0.0
     ... """.format(server_url=server_url))
@@ -329,6 +331,7 @@ We can provide a shards whitelist::
     ...
     ... [versions]
     ... setuptools = <45.0
+    ... zc.buildout = 2.13.8
     ... Jinja2 = <3.0.0
     ... MarkupSafe = <2.0.0
     ... """.format(server_url=server_url))
@@ -402,6 +405,7 @@ We can override the solr settings with a configoverlay:
     ...
     ... [versions]
     ... setuptools = <45.0
+    ... zc.buildout = 2.13.8
     ... Jinja2 = <3.0.0
     ... MarkupSafe = <2.0.0
     ... """.format(server_url=server_url))

--- a/ftw/recipe/solr/README.txt
+++ b/ftw/recipe/solr/README.txt
@@ -168,6 +168,7 @@ We should also have a startup script::
     <BLANKLINE>
     DEFAULT_JVM_OPTS="-Dfile.encoding=UTF-8"
     JVM_OPTS=(${DEFAULT_JVM_OPTS[@]} -Xms512m -Xmx512m -Xss256k)
+    EXTRA_OPTS=()
     <BLANKLINE>
     JAVACMD="java"
     PID_FILE=${PID_FILE:="/sample-buildout/var/solr/solr.pid"}
@@ -186,7 +187,8 @@ We should also have a startup script::
     -Dsolr.install.dir=$SOLR_INSTALL_DIR \
     -Dsolr.log.dir=/sample-buildout/var/log \
     -Dlog4j2.formatMsgNoLookups=true \
-    -Dlog4j2.configurationFile=/sample-buildout/parts/solr/log4j2.xml)
+    -Dlog4j2.configurationFile=/sample-buildout/parts/solr/log4j2.xml \
+    "${EXTRA_OPTS[@]}")
     <BLANKLINE>
     start() {
         cd "$SOLR_SERVER_DIR"

--- a/ftw/recipe/solr/__init__.py
+++ b/ftw/recipe/solr/__init__.py
@@ -143,6 +143,7 @@ class Recipe(object):
             startup_script,
             pid_file=self.options['pid-file'],
             jvm_opts=self.options['jvm-opts'],
+            extra_opts=self.options['extra-opts'],
             solr_port=self.options['port'],
             solr_host=self.options['host'],
             solr_home=home_dir,

--- a/ftw/recipe/solr/defaults.py
+++ b/ftw/recipe/solr/defaults.py
@@ -4,4 +4,5 @@ DEFAULT_OPTIONS = {
     'host': 'localhost',
     'port': '8983',
     'jvm-opts': '-Xms512m -Xmx512m -Xss256k',
+    'extra-opts': '',
 }

--- a/ftw/recipe/solr/templates/startup.tmpl
+++ b/ftw/recipe/solr/templates/startup.tmpl
@@ -2,6 +2,7 @@
 
 DEFAULT_JVM_OPTS="-Dfile.encoding=UTF-8"
 JVM_OPTS=(${DEFAULT_JVM_OPTS[@]} {{ jvm_opts }})
+EXTRA_OPTS=({{ extra_opts }})
 
 JAVACMD="java"
 PID_FILE=${PID_FILE:="{{ pid_file }}"}
@@ -20,7 +21,8 @@ SOLR_START_OPT=('-server' \
 -Dsolr.install.dir=$SOLR_INSTALL_DIR \
 -Dsolr.log.dir={{ log_dir }} \
 -Dlog4j2.formatMsgNoLookups=true \
--Dlog4j2.configurationFile=file:{{ log4j2_xml }})
+-Dlog4j2.configurationFile=file:{{ log4j2_xml }} \
+"${EXTRA_OPTS[@]}")
 
 start() {
     cd "$SOLR_SERVER_DIR"


### PR DESCRIPTION
Add support for `extra-opts`.

This allows to pass additional options to the Solr command line. Needed to add `-Dsolr.disable.shardsWhitelist=true` for deployments were we have master/slave replication and a recent Solr version.

Instead of making a boolean recipe option just for that, I decided to go with an `extra-opts` that should give us more flexibility in the future.

Testing job for `ftw.recipe.solr` is now fixed on Jenkins as well _(I disabled the old one and kept it around though)_.