### PR TITLE
Use system property to enable remote streaming

### DIFF
--- a/HISTORY.txt
+++ b/HISTORY.txt
@@ -4,7 +4,8 @@ Changelog
 1.3.9 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Use system property to enable remote streaming.
+  [buchi]
 
 
 1.3.8 (2023-10-12)

--- a/ftw/recipe/solr/README.txt
+++ b/ftw/recipe/solr/README.txt
@@ -186,6 +186,7 @@ We should also have a startup script::
     -Dsolr.solr.home=$SOLR_HOME \
     -Dsolr.install.dir=$SOLR_INSTALL_DIR \
     -Dsolr.log.dir=/sample-buildout/var/log \
+    -Dsolr.enableRemoteStreaming=true \
     -Dlog4j2.formatMsgNoLookups=true \
     -Dlog4j2.configurationFile=/sample-buildout/parts/solr/log4j2.xml \
     "${EXTRA_OPTS[@]}")

--- a/ftw/recipe/solr/__init__.py
+++ b/ftw/recipe/solr/__init__.py
@@ -148,6 +148,7 @@ class Recipe(object):
             solr_host=self.options['host'],
             solr_home=home_dir,
             solr_install_dir=destination,
+            enable_remote_streaming=self.options['enable-remote-streaming'],
             log_dir=log_dir,
             log4j2_xml=log4j2_xml,
         ))

--- a/ftw/recipe/solr/defaults.py
+++ b/ftw/recipe/solr/defaults.py
@@ -5,4 +5,5 @@ DEFAULT_OPTIONS = {
     'port': '8983',
     'jvm-opts': '-Xms512m -Xmx512m -Xss256k',
     'extra-opts': '',
+    'enable-remote-streaming': 'true',
 }

--- a/ftw/recipe/solr/templates/startup.tmpl
+++ b/ftw/recipe/solr/templates/startup.tmpl
@@ -20,6 +20,7 @@ SOLR_START_OPT=('-server' \
 -Dsolr.solr.home=$SOLR_HOME \
 -Dsolr.install.dir=$SOLR_INSTALL_DIR \
 -Dsolr.log.dir={{ log_dir }} \
+-Dsolr.enableRemoteStreaming={{ enable_remote_streaming }} \
 -Dlog4j2.formatMsgNoLookups=true \
 -Dlog4j2.configurationFile=file:{{ log4j2_xml }} \
 "${EXTRA_OPTS[@]}")


### PR DESCRIPTION
Since Solr 8.11.3 it's no longer possible to enable it in solrconfig.xml